### PR TITLE
Improve error handling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,11 @@ fn main() -> anyhow::Result<()> {
     // let mut image = image_loader::load_images("./testing/sample", None).unwrap();
     // let splitpoints = splitter::find_splitpoints_debug(&mut image, 5000, 5, 240);
     let now = Instant::now();
-    let image = image_loader::load_images(image_loader::find_images("./testing/sample")?.as_ref(), Some(800)).unwrap();
+    let image = image_loader::load_images(
+        image_loader::find_images("./testing/sample")?.as_ref(),
+        Some(800),
+    )
+    .unwrap();
     println!("Images loaded in {:.2?}", now.elapsed());
     let now = Instant::now();
     let splitpoints = splitter::find_splitpoints(&image, 5000, 5, 242);

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,12 +5,12 @@ use quickstitch::gui;
 use quickstitch::stitcher::splitter::split_image;
 use quickstitch::stitcher::{image_loader, splitter};
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     // dbg!(image_loader::find_images("./testing/sample"));
     // let mut image = image_loader::load_images("./testing/sample", None).unwrap();
     // let splitpoints = splitter::find_splitpoints_debug(&mut image, 5000, 5, 240);
     let now = Instant::now();
-    let image = image_loader::load_images("./testing/sample", Some(800)).unwrap();
+    let image = image_loader::load_images(image_loader::find_images("./testing/sample")?.as_ref(), Some(800)).unwrap();
     println!("Images loaded in {:.2?}", now.elapsed());
     let now = Instant::now();
     let splitpoints = splitter::find_splitpoints(&image, 5000, 5, 242);
@@ -18,4 +18,6 @@ fn main() {
     let now = Instant::now();
     split_image(&image, &splitpoints, PathBuf::from("./testing/output"), 100);
     println!("Split image in {:.2?}", now.elapsed());
+
+    Ok(())
 }


### PR DESCRIPTION
Remove usage of anyhow in library code, improve ImageLoaderError instead.

Cleaned up some of the image loading code and made the API a little more flexible.

Removed usages of `find_images` within `load_images`. Ideally, one should call `find_images` *before* using `load_images` once instead, and then load all the resulting images.