### PR TITLE
Isolate GUI deps and only use required image deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,23 @@ name = "quickstitch"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+gui = ["dep:iced"]
+
 [dependencies]
 anyhow = "1.0.86"
-image = "0.25.2"
+image = { version = "0.25.2", features = ["rayon", "jpeg", "png", "webp"] }
 natord = "1.0.9"
 rayon = "1.10.0"
 thiserror = "1.0.63"
-iced = { git = "https://github.com/iced-rs/iced", rev = "043f0302142e46bf1d7ba2015f83261813280fec" }
 itertools = "0.13.0"
+
+# gui deps
+iced = { git = "https://github.com/iced-rs/iced", rev = "043f0302142e46bf1d7ba2015f83261813280fec", optional = true }
 
 [dev-dependencies]
 criterion = "0.5.1"
+
+[[bin]]
+name = "quickstitch"
+required-features = ["gui"]


### PR DESCRIPTION
Currently, [iced](https://github.com/iced-rs/iced) is a global dependency and all formats supported by [image](https://github.com/image-rs/image) are included as dependencies. This is bad for first-time compilation times, and especially causes unnecessary overhead if running tests or https://github.com/quietkiro/quickstitch/pull/3 is implemented and only the cli needs to be compiled. 

In order to reduce this overhead, I created a `gui` feature and made the `quickstitch` binary require it, isolating `iced` into the `gui` feature. I also only included jpeg, png, webp, and rayon support from the `image` library, reducing compile-time overhead there as well.