### PR TITLE
Implement sort option for cli

### DIFF
--- a/src/bin/qstitch.rs
+++ b/src/bin/qstitch.rs
@@ -1,42 +1,8 @@
 use anyhow::Result;
-use clap::{Args, Parser, ValueEnum};
+use clap::{Args, Parser};
 use quickstitch as qs;
 use quickstitch::{ImageOutputFormat, Loaded, Stitcher};
 use std::path::{Path, PathBuf};
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
-enum Sort {
-    /// Sorts files lexicographically, treating numbers as strings of digits
-    /// and not as atomic numbers.
-    ///
-    /// Example: ["8.jpeg", "9.jpeg", "10.jpeg"] --> ["10.jpeg", "8.jpeg", "9.jpeg"]. 
-    /// Note that sorting is done by comparing Unicode code points.
-    #[clap(alias = "l")]
-    Logical,
-    /// Treats numbers atomically, sorting them by numerical value.
-    ///
-    /// Example: ["10.jpeg", "8.jpeg", "9.jpeg"] --> ["8.jpeg", "9.jpeg", "10.jpeg"].
-    #[clap(alias = "n")]
-    Natural,
-}
-
-impl From<qs::Sort> for Sort {
-    fn from(value: qs::Sort) -> Self {
-        match value {
-            qs::Sort::Logical => Self::Logical,
-            qs::Sort::Natural => Self::Natural,
-        }
-    }
-}
-
-impl From<Sort> for qs::Sort {
-    fn from(value: Sort) -> Self {
-        match value {
-            Sort::Logical => qs::Sort::Logical,
-            Sort::Natural => qs::Sort::Natural,
-        }
-    }
-}
 
 /// Quickly stitch raws.
 ///
@@ -55,9 +21,9 @@ struct Cli {
     /// Given the images ["9.jpeg", "10.jpeg", "8.jpeg", "11.jpeg"]:
     ///   - Logical: ["10.jpeg", "11.jpeg", 8.jpeg", "9.jpeg"]
     ///   - Natural: ["8.jpeg", "9.jpeg", "10.jpeg", "11.jpeg"]
-    #[clap(long, short, default_value_t = Sort::Natural, verbatim_doc_comment)]
+    #[clap(long, short, default_value_t = qs::Sort::Natural, verbatim_doc_comment)]
     #[arg(value_enum)]
-    sort: Sort,
+    sort: qs::Sort,
     // TODO: add more arguments for target height, scan interval, etc. to further customize output
 }
 

--- a/src/bin/qstitch.rs
+++ b/src/bin/qstitch.rs
@@ -1,7 +1,42 @@
 use anyhow::Result;
-use clap::{Args, Parser};
+use clap::{Args, Parser, ValueEnum};
+use quickstitch as qs;
 use quickstitch::{ImageOutputFormat, Loaded, Stitcher};
 use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum Sort {
+    /// Sorts files lexicographically, treating numbers as strings of digits
+    /// and not as atomic numbers.
+    ///
+    /// Example: ["8.jpeg", "9.jpeg", "10.jpeg"] --> ["10.jpeg", "8.jpeg", "9.jpeg"]. 
+    /// Note that sorting is done by comparing Unicode code points.
+    #[clap(alias = "l")]
+    Logical,
+    /// Treats numbers atomically, sorting them by numerical value.
+    ///
+    /// Example: ["10.jpeg", "8.jpeg", "9.jpeg"] --> ["8.jpeg", "9.jpeg", "10.jpeg"].
+    #[clap(alias = "n")]
+    Natural,
+}
+
+impl From<qs::Sort> for Sort {
+    fn from(value: qs::Sort) -> Self {
+        match value {
+            qs::Sort::Logical => Self::Logical,
+            qs::Sort::Natural => Self::Natural,
+        }
+    }
+}
+
+impl From<Sort> for qs::Sort {
+    fn from(value: Sort) -> Self {
+        match value {
+            Sort::Logical => qs::Sort::Logical,
+            Sort::Natural => qs::Sort::Natural,
+        }
+    }
+}
 
 /// Quickly stitch raws.
 ///
@@ -15,6 +50,15 @@ struct Cli {
     /// The output directory to place the stitched images in.
     #[clap(long, short)]
     output: Option<PathBuf>,
+    /// The sorting method used to sort the images before stitching (only works with `--dir`).
+    ///
+    /// Given the images ["9.jpeg", "10.jpeg", "8.jpeg", "11.jpeg"]:
+    ///   - Logical: ["10.jpeg", "11.jpeg", 8.jpeg", "9.jpeg"]
+    ///   - Natural: ["8.jpeg", "9.jpeg", "10.jpeg", "11.jpeg"]
+    #[clap(long, short, default_value_t = Sort::Natural, verbatim_doc_comment)]
+    #[arg(value_enum)]
+    sort: Sort,
+    // TODO: add more arguments for target height, scan interval, etc. to further customize output
 }
 
 #[derive(Debug, Clone, Args)]
@@ -36,10 +80,10 @@ fn main() -> Result<()> {
             let paths: Vec<&Path> = images.iter().map(PathBuf::as_path).collect();
             stitcher.load(&paths, None, true)?
         }
-        (None, Some(dir)) => stitcher.load_dir(&dir, None, true)?,
+        (None, Some(dir)) => stitcher.load_dir(&dir, None, true, cli.sort.into())?,
         _ => unimplemented!("arg group rules ensure only one of the two is provided"),
     };
-    let stitched = loaded.stitch(1000, 5, 220);
+    let stitched = loaded.stitch(5000, 5, 220);
 
     // TODO: handle errors here someday
     match cli.output {

--- a/src/stitcher/image_loader.rs
+++ b/src/stitcher/image_loader.rs
@@ -53,8 +53,14 @@ impl From<io::Error> for ImageLoaderError {
     }
 }
 
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Sort {
+    #[cfg_attr(feature = "cli", clap(alias = "l"))]
+    #[cfg_attr(feature = "cli", clap(help = "Sorts files lexicographically, treating numbers as strings of digits and not as atomic numbers."))]
     Logical,
+    #[cfg_attr(feature = "cli", clap(alias = "n"))]
+    #[cfg_attr(feature = "cli", clap(help = "Treats numbers in the file name atomically, sorting them by numerical value."))]
     Natural,
 }
 


### PR DESCRIPTION
Added optional flag `--sort` with the options `logical` and `natural` (default value of `natural`).